### PR TITLE
docs: clarify X Windows vs Microsoft Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This is NOT the official HamClock installation method. This is a community-creat
 - Provides automated updates and service management
 - Is optimized for dedicated display installations
 
+**Note: "X Windows" (also known as X11 or X Window System) is the standard graphics system used in Linux - it is **NOT** related to Microsoft Windows. HamClock is a Linux application and cannot run natively on Microsoft Windows. For more information about X Windows, see [Wikipedia's X Window System article](https://en.wikipedia.org/wiki/X_Window_System).**
+
 For the official HamClock installation method using X Windows, please visit:
 https://www.clearskyinstitute.com/ham/HamClock/#tab-key
 


### PR DESCRIPTION
Added clear explanation about X Windows (X11) to prevent confusion with Microsoft Windows. Includes link to Wikipedia article for those wanting to learn more about Linux display systems.

- Added bold notice in Important Notice section
- Improved clarity for new Linux users
- Added reference link to X Window System article