### PR TITLE
Fix logger redirection broken by overzealous linting

### DIFF
--- a/hamclock-update.sh
+++ b/hamclock-update.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # error handling and logging
 set -euo pipefail
-exec 1> /dev/null
-logger -s -t "$(basename "$0")"
+exec 1> >(logger -s -t "$(basename "$0")") 2>&1
 
 # Add lock file to prevent concurrent runs
 LOCKFILE="/var/run/hamclock_update.lock"


### PR DESCRIPTION
- Restore working process substitution for logger
- Revert "simplified" redirection that broke functionality
- Add proper stdout/stderr handling through logger

Sometimes linters are like that friend who keeps "helping" adjust your antenna - they mean well, but they don't always understand the real-world implications of their changes. Trust working code over style guides.