### PR TITLE
fix: ensure services remain enabled after updates

### DIFF
--- a/hamclock-update.service
+++ b/hamclock-update.service
@@ -9,6 +9,8 @@ ExecStart=/usr/local/sbin/hamclock-update
 User=root
 TimeoutStartSec=1800
 RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Add service enablement in wrapper script update block
- Enable both hamclock.service and hamclock-update.timer
- Start timer immediately after enabling
- Simplify by removing redundant status checks

This ensures services stay enabled even if manually disabled, maintaining system reliability during updates.