### PR TITLE
feat: Improve update logging and output formatting

### DIFF
--- a/hamclock-update.sh
+++ b/hamclock-update.sh
@@ -252,15 +252,17 @@ export DEBIAN_FRONTEND=noninteractive
 ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 
 # Run apt update, no need for the output
+logger -s -t "$(basename "$0")" "Checking for system updates..."
 apt update &> /dev/null
 
 UPDATES=$(apt list --upgradable | wc -l)
+logger -s -t "$(basename "$0")" "Found $((UPDATES -= 1)) packages to update"
 
 if [ "$UPDATES" -gt 1 ]; then
-  logger -s -t "$(basename "$0")" "Updating $((UPDATES -= 1)) packages"
   systemctl stop hamclock.service
 
   # First handle regular updates
+  logger -s -t "$(basename "$0")" "Starting system update"
   apt upgrade -y
 
   # Explicitly handle tzdata if it's held back
@@ -268,6 +270,7 @@ if [ "$UPDATES" -gt 1 ]; then
     apt install --only-upgrade -y --allow-change-held-packages tzdata
   fi
 
+  logger -s -t "$(basename "$0")" "System update complete, rebooting"
   shutdown -r now
 elif [ "$HCUPDATE" -eq 1 ]; then
   logger -s -t "$(basename "$0")" "Restarting hamclock"

--- a/hamclock-update.sh
+++ b/hamclock-update.sh
@@ -252,7 +252,7 @@ export DEBIAN_FRONTEND=noninteractive
 ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 
 # Run apt update, no need for the output
-apt update > /dev/null 2>&1
+apt update &> /dev/null
 
 UPDATES=$(apt list --upgradable | wc -l)
 

--- a/update.html
+++ b/update.html
@@ -112,8 +112,8 @@
 
                         eventSource.onmessage = function(event) {
                             const log = document.getElementById('log');
-                            // Replace any existing newlines with <br> and add new content
-                            log.innerHTML = log.innerHTML.replace(/\n/g, '<br>') + event.data.replace(/\n/g, '<br>');
+                            // Add new content with <br> tags
+                            log.innerHTML += event.data + '<br>';
                             log.scrollTop = log.scrollHeight;
                         };
 

--- a/update_server.py
+++ b/update_server.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 import sys
 from datetime import datetime
+import re
 
 # Configure logging
 logging.basicConfig(
@@ -229,6 +230,16 @@ class UpdateHandler(http.server.SimpleHTTPRequestHandler):
                         if not line and process.poll() is not None:
                             break
                         if line:
+                            # Clean up logger output
+                            # Remove <13> prefix and duplicate timestamps
+                            line = line.replace("<13>", "")
+                            # Remove duplicate timestamp pattern
+                            # (e.g., "May  9 02:27:11 hamclock-update: ")
+                            line = re.sub(
+                                r"^[A-Za-z]+\s+\d+\s+\d+:\d+:\d+\s+hamclock-update:\s+",
+                                "",
+                                line,
+                            )
                             # Ensure each line ends with a newline
                             if not line.endswith("\n"):
                                 line += "\n"


### PR DESCRIPTION
- Clean up logger output by removing duplicate timestamps and <13> prefixes
- Add informative log messages for system update process:
  - "Checking for system updates..."
  - "Found X packages to update"
  - "Starting system update"
  - "System update complete, rebooting"
- Suppress apt warning by redirecting output
- Fix newline handling in web interface