### PR TITLE
Refactor installation paths to support dynamic base directory

### DIFF
--- a/hamclock-update-web.service
+++ b/hamclock-update-web.service
@@ -5,7 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/sbin/update_server.py
+EnvironmentFile=/etc/default/hamclock
+ExecStart=/bin/bash -c '$HAMCLOCK_BASE_DIR/sbin/update_server.py'
 User=root
 Restart=always
 RestartSec=10

--- a/hamclock-update.service
+++ b/hamclock-update.service
@@ -5,7 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/sbin/hamclock-update
+EnvironmentFile=/etc/default/hamclock
+ExecStart=/bin/bash -c '$HAMCLOCK_BASE_DIR/sbin/hamclock-update'
 User=root
 TimeoutStartSec=1800
 StandardOutput=journal

--- a/hamclock-update.sh
+++ b/hamclock-update.sh
@@ -104,6 +104,14 @@ fi
 HAMCLOCK_BRANCH=${HAMCLOCK_BRANCH:-master}
 HAMCLOCK_AUTO_UPDATE=${HAMCLOCK_AUTO_UPDATE:-0}
 HAMCLOCK_AUTO_REBOOT=${HAMCLOCK_AUTO_REBOOT:-1}
+HAMCLOCK_BASE_DIR=${HAMCLOCK_BASE_DIR:-/usr/local}
+
+if [ -d /usr/local/bin/.git ] || [ -d /usr/local/sbin/.git ]; then
+    HAMCLOCK_BASE_DIR=/usr
+    if [ "$HAMCLOCK_BASE_DIR" != "/usr" ]; then
+        echo "HAMCLOCK_BASE_DIR=$HAMCLOCK_BASE_DIR" >> /etc/default/hamclock
+    fi
+fi
 
 log info "Checking for wrapper script updates..."
 
@@ -122,7 +130,6 @@ fi
 # Check for updates to the wrapper scripts
 if [ "$TEST_MODE" -eq 0 ]; then
     REPO_URL="https://github.com/k4drw/hamclock-fb"
-    INSTALL_DIR="/usr/local"
     REPO_DIR="/var/cache/hamclock/repo"
 
     # Clone or update repo
@@ -145,7 +152,7 @@ if [ "$TEST_MODE" -eq 0 ]; then
     UPDATE_NEEDED=false
 
     # Check hamclock-update.sh
-    if [ -f "$REPO_DIR/hamclock-update.sh" ] && ! cmp -s "$REPO_DIR/hamclock-update.sh" "$INSTALL_DIR/sbin/hamclock-update"; then
+    if [ -f "$REPO_DIR/hamclock-update.sh" ] && ! cmp -s "$REPO_DIR/hamclock-update.sh" "$HAMCLOCK_BASE_DIR/sbin/hamclock-update"; then
         UPDATE_NEEDED=true
         log info "Update script has changed"
     fi
@@ -160,7 +167,7 @@ if [ "$TEST_MODE" -eq 0 ]; then
 
     # Check web interface files
     for web_file in update_server.py update.html; do
-        if [ -f "$REPO_DIR/$web_file" ] && ! cmp -s "$REPO_DIR/$web_file" "/usr/local/sbin/$web_file"; then
+        if [ -f "$REPO_DIR/$web_file" ] && ! cmp -s "$REPO_DIR/$web_file" "$HAMCLOCK_BASE_DIR/sbin/$web_file"; then
             UPDATE_NEEDED=true
             log info "Web interface file $web_file has changed"
         fi
@@ -169,13 +176,13 @@ if [ "$TEST_MODE" -eq 0 ]; then
     # Update files if needed
     if $UPDATE_NEEDED; then
         # Update the scripts
-        install -m 755 "$REPO_DIR/hamclock-update.sh" "$INSTALL_DIR/sbin/hamclock-update"
+        install -m 755 "$REPO_DIR/hamclock-update.sh" "$HAMCLOCK_BASE_DIR/sbin/hamclock-update"
         install -m 644 "$REPO_DIR/hamclock.service" /etc/systemd/system/
         install -m 644 "$REPO_DIR/hamclock-update.service" /etc/systemd/system/
         install -m 644 "$REPO_DIR/hamclock-update.timer" /etc/systemd/system/
         install -m 644 "$REPO_DIR/hamclock-update-web.service" /etc/systemd/system/
-        install -m 755 "$REPO_DIR/update_server.py" /usr/local/sbin/
-        install -m 644 "$REPO_DIR/update.html" /usr/local/sbin/
+        install -m 755 "$REPO_DIR/update_server.py" "$HAMCLOCK_BASE_DIR/sbin/"
+        install -m 644 "$REPO_DIR/update.html" "$HAMCLOCK_BASE_DIR/sbin/"
         systemctl daemon-reload
         log info "Wrapper scripts updated"
 
@@ -190,7 +197,7 @@ if [ "$TEST_MODE" -eq 0 ]; then
 
         # Exit and let the new version take over
         log info "Launching new version with --updated"
-        "$INSTALL_DIR/sbin/hamclock-update" --updated &
+        "$HAMCLOCK_BASE_DIR/sbin/hamclock-update" --updated &
         exit 0
     else
         log info "No updates to wrapper scripts needed"
@@ -288,12 +295,8 @@ if [ "$HCUPDATE" -eq 1 ]; then
 
         make -j"$MAKE_JOBS" "$RESOLUTION"
     fi
-    if [ -d /usr/local/bin/.git ]; then
-        log info "/usr/local/bin is a git repo, installing hamclock to /usr/bin/"
-        install -m 4755 $RESOLUTION /usr/bin/hamclock
-    else
-        make install
-    fi
+
+    install -m 4755 $RESOLUTION "$HAMCLOCK_BASE_DIR/bin/hamclock"
 
     # Remove the extracted files
     cd /var/cache/hamclock

--- a/hamclock.service
+++ b/hamclock.service
@@ -7,7 +7,7 @@ Description=Hamclock
 Type=simple
 EnvironmentFile=/etc/default/hamclock
 # User is set directly in ExecStart using sudo
-ExecStart=/bin/bash -c 'sudo -u $HAMCLOCK_USER /usr/bin/env hamclock -k -t 50 -f on -o'
+ExecStart=/bin/bash -c 'sudo -u $HAMCLOCK_USER $HAMCLOCK_BASE_DIR/bin/hamclock -k -t 50 -f on -o'
 Restart=always
 RestartSec=3
 TimeoutStartSec=30

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,12 @@ fi
 # Set default branch if not specified
 HAMCLOCK_BRANCH=${HAMCLOCK_BRANCH:-master}
 
+# Determine base directory
+HAMCLOCK_BASE_DIR=/usr/local
+if [ -d /usr/local/bin/.git ] || [ -d /usr/local/sbin/.git ]; then
+    HAMCLOCK_BASE_DIR=/usr
+fi
+
 # Install required packages
 echo "Installing required packages..."
 apt update > /dev/null 2>&1
@@ -35,13 +41,13 @@ fi
 
 # Install update script
 echo "Installing hamclock-update script..."
-install -m 755 "$TEMP_DIR/hamclock-update.sh" /usr/local/sbin/hamclock-update
+install -m 755 "$TEMP_DIR/hamclock-update.sh" $HAMCLOCK_BASE_DIR/sbin/hamclock-update
 
 # Install web interface
 echo "Installing web interface..."
-install -m 755 "$TEMP_DIR/update_server.py" /usr/local/sbin/update_server.py
-install -m 644 "$TEMP_DIR/update.html" /usr/local/sbin/update.html
-install -m 644 "$TEMP_DIR/favicon.png" /usr/local/sbin/favicon.png || true # Optional favicon
+install -m 755 "$TEMP_DIR/update_server.py" $HAMCLOCK_BASE_DIR/sbin/update_server.py
+install -m 644 "$TEMP_DIR/update.html" $HAMCLOCK_BASE_DIR/sbin/update.html
+install -m 644 "$TEMP_DIR/favicon.png" $HAMCLOCK_BASE_DIR/sbin/favicon.png || true # Optional favicon
 install -m 644 "$TEMP_DIR/hamclock-update-web.service" /etc/systemd/system/hamclock-update-web.service
 
 # Install service files
@@ -76,6 +82,7 @@ fi
 cat > /etc/default/hamclock << EOF
 HAMCLOCK_USER=$DEFAULT_USER
 HAMCLOCK_BRANCH=$HAMCLOCK_BRANCH
+HAMCLOCK_BASE_DIR=$HAMCLOCK_BASE_DIR
 HAMCLOCK_UPDATE_PORT=8088
 HAMCLOCK_STATUS_INTERVAL=5
 HAMCLOCK_AUTO_UPDATE=0
@@ -83,7 +90,7 @@ EOF
 
 # Run the update script once to download and install hamclock
 echo "Running initial update to download and install hamclock..."
-if ! /usr/local/sbin/hamclock-update; then
+if ! $HAMCLOCK_BASE_DIR/sbin/hamclock-update; then
     echo "Initial update failed. This is normal if HamClock is not yet installed."
     echo "The update will be attempted again during the scheduled update time."
 fi

--- a/update_server.py
+++ b/update_server.py
@@ -37,6 +37,7 @@ def load_config() -> Dict[str, str]:
         "HAMCLOCK_UPDATE_PORT": "8088",
         "HAMCLOCK_BRANCH": "master",
         "HAMCLOCK_STATUS_INTERVAL": "30",  # seconds
+        "HAMCLOCK_BASE_DIR": "/usr/local",
     }
 
     try:
@@ -59,8 +60,9 @@ def load_config() -> Dict[str, str]:
 # Load configuration
 CONFIG = load_config()
 PORT = int(os.getenv("HAMCLOCK_UPDATE_PORT", CONFIG["HAMCLOCK_UPDATE_PORT"]))
+BASE_DIR = os.getenv("HAMCLOCK_BASE_DIR", CONFIG["HAMCLOCK_BASE_DIR"])
 UPDATE_LOG = "/var/log/hamclock-update.log"
-HTML_PATH = "/usr/local/sbin/update.html"
+HTML_PATH = os.path.join(BASE_DIR, "sbin", "update.html")
 STATUS_UPDATE_INTERVAL = int(
     os.getenv("HAMCLOCK_STATUS_INTERVAL", CONFIG["HAMCLOCK_STATUS_INTERVAL"])
 )  # seconds
@@ -187,7 +189,7 @@ def run_update() -> Union[bool, str]:
         Union[bool, str]: True if update started successfully, error message otherwise.
     """
     try:
-        update_script = "/usr/local/sbin/hamclock-update"
+        update_script = os.path.join(BASE_DIR, "sbin", "hamclock-update")
         if not os.path.exists(update_script):
             return "Update script not found"
 
@@ -278,7 +280,7 @@ class UpdateHandler(http.server.SimpleHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-type", "image/png")
         self.end_headers()
-        favicon_path = "/usr/local/sbin/favicon.png"
+        favicon_path = os.path.join(BASE_DIR, "sbin", "favicon.png")
         if os.path.exists(favicon_path):
             with open(favicon_path, "rb") as f:
                 self.wfile.write(f.read())
@@ -293,7 +295,7 @@ class UpdateHandler(http.server.SimpleHTTPRequestHandler):
         self.end_headers()
 
         try:
-            update_script = "/usr/local/sbin/hamclock-update"
+            update_script = os.path.join(BASE_DIR, "sbin", "hamclock-update")
             if not os.path.exists(update_script):
                 self.wfile.write(b"data: Error: Update script not found\n\n")
                 return


### PR DESCRIPTION
- Introduce HAMCLOCK_BASE_DIR to support installation in /usr or /usr/local
- Update install.sh to detect base dir early and persist it to config
- Update hamclock-update.sh to respect configured base dir
- Update systemd services to load config environment and use dynamic paths via bash wrapper
- Update update_server.py to read base dir from config instead of hardcoded paths
- Fix various syntax and logic errors in path handling